### PR TITLE
Small change to axios.ts nested ifs

### DIFF
--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -13,6 +13,7 @@ declare module '@vue/runtime-core' {
 // good idea to move this instance creation inside of the
 // "export default () => {}" function below (which runs individually
 // for each client)
+// FIXME: Hidden if/else chain is a code smell, fix it.
 let api: AxiosInstance
 if(!process.env.DEV)
   api = axios.create({ baseURL: 'https://api.tdl.app' });

--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -13,17 +13,12 @@ declare module '@vue/runtime-core' {
 // good idea to move this instance creation inside of the
 // "export default () => {}" function below (which runs individually
 // for each client)
-// FIXME: Nested if statements are a code smell, fix it.
 let api: AxiosInstance
-if (process.env.DEV) {
-  if (process.env.MODE === 'capacitor') {
-    api = axios.create({ baseURL: 'http://10.0.2.2:3000' })
-  } else {
-    api = axios.create({ baseURL: 'http://localhost:3000' })
-  }
-} else {
+if(!process.env.DEV)
   api = axios.create({ baseURL: 'https://api.tdl.app' });
-}
+else if(process.env.MODE === 'capacitor')
+  api = axios.create({ baseURL: 'http://10.0.2.2:3000' });
+else api = axios.create({ baseURL: 'https://localhost:3000' });
 
 // Technically we don't need to tell it about the store state interface, but
 // knowing that this is possible is very useful in itself.


### PR DESCRIPTION
When a function distributes amongst three separate conditions it can be difficult to reduce the code down. Switch statements could work - in this case it might not. For now I just flattened the nested structure. `if(!process.env.DEV)` isn't saying exactly the same thing as it did: `if(process.env.DEV)` however in this case there should be no change in behavior.